### PR TITLE
Add OCR extraction service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# document-management
+# Document Management API
+
+This repository contains a minimal FastAPI application for managing documents.
+It now includes basic OCR functionality using Tesseract and pdf2image.
+
+## Features
+
+- Create and list document metadata.
+- Extract text from uploaded PDF files via the `/ocr/extract` endpoint.
+
+## Development
+
+Install dependencies from `requirements.txt` and run the tests with `pytest`.

--- a/backend/app/controllers/ocr_controller.py
+++ b/backend/app/controllers/ocr_controller.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""OCR endpoints."""
+
+import os
+import shutil
+import tempfile
+
+from fastapi import APIRouter, File, HTTPException, UploadFile
+
+from ..services.ocr_service import extract_text_from_pdf
+
+router = APIRouter()
+
+
+@router.post("/extract")
+async def extract_text(file: UploadFile = File(...)) -> dict[str, str]:
+    """Extract text from an uploaded PDF file using OCR."""
+    if file.content_type != "application/pdf":
+        raise HTTPException(status_code=400, detail="Only PDF files are supported")
+
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp:
+            shutil.copyfileobj(file.file, tmp)
+            tmp_path = tmp.name
+
+        text = extract_text_from_pdf(tmp_path)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - external tool failure
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    finally:
+        file.file.close()
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+    return {"text": text}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
-from .routes import document_routes
+from .routes import document_routes, ocr_routes
 
 app = FastAPI(title="Document Management API")
 
 app.include_router(document_routes.router, prefix="/documents", tags=["documents"])
+app.include_router(ocr_routes.router, prefix="/ocr", tags=["ocr"])
 
 @app.get("/")
 def read_root():

--- a/backend/app/routes/ocr_routes.py
+++ b/backend/app/routes/ocr_routes.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+"""Routes for OCR operations."""
+
+from fastapi import APIRouter
+from ..controllers import ocr_controller
+
+router = APIRouter()
+router.include_router(ocr_controller.router)

--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+"""OCR extraction service using Tesseract and pdf2image."""
+
+from typing import List
+import os
+
+from pdf2image import convert_from_path
+import pytesseract
+
+
+def extract_text_from_pdf(pdf_path: str) -> str:
+    """Extract text from a PDF file.
+
+    This converts each PDF page to an image using ``pdf2image`` and runs
+    Tesseract OCR on the result.
+
+    Parameters
+    ----------
+    pdf_path:
+        Path to the PDF document.
+
+    Returns
+    -------
+    str
+        The text recognized from all pages.
+
+    Raises
+    ------
+    FileNotFoundError
+        If ``pdf_path`` does not point to an existing file.
+    RuntimeError
+        If conversion or OCR fails.
+    """
+    if not os.path.isfile(pdf_path):
+        raise FileNotFoundError(f"{pdf_path} does not exist")
+
+    try:
+        # Use a moderate DPI to balance quality and performance
+        images = convert_from_path(pdf_path, dpi=200)
+    except Exception as exc:  # pragma: no cover - external tool failure
+        raise RuntimeError(f"Failed converting PDF to images: {exc}") from exc
+
+    texts: List[str] = []
+    for img in images:
+        try:
+            texts.append(pytesseract.image_to_string(img))
+        except Exception as exc:  # pragma: no cover - external tool failure
+            raise RuntimeError(f"Tesseract OCR failed: {exc}") from exc
+        finally:
+            img.close()
+
+    return "\n".join(texts)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pdf2image
+pytesseract

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,6 @@
 from fastapi.testclient import TestClient
 from backend.app.main import app
+from unittest import mock
 
 client = TestClient(app)
 
@@ -18,3 +19,25 @@ def test_create_and_list_documents():
     list_resp = client.get("/documents/")
     assert list_resp.status_code == 200
     assert list_resp.json() == [doc]
+
+
+def test_ocr_endpoint(monkeypatch, tmp_path):
+    sample_pdf = tmp_path / "sample.pdf"
+    sample_pdf.write_bytes(b"dummy")
+
+    def fake_extract(path):
+        assert path == str(sample_pdf)
+        return "ocr text"
+
+    monkeypatch.setattr(
+        "backend.app.services.ocr_service.extract_text_from_pdf", fake_extract
+    )
+
+    with sample_pdf.open("rb") as f:
+        resp = client.post(
+            "/ocr/extract",
+            files={"file": ("sample.pdf", f, "application/pdf")},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "ocr text"}

--- a/tests/test_ocr_service.py
+++ b/tests/test_ocr_service.py
@@ -1,0 +1,28 @@
+import os
+from unittest import mock
+import pytest
+
+from backend.app.services.ocr_service import extract_text_from_pdf
+
+
+def test_extract_text_from_pdf(monkeypatch, tmp_path):
+    pdf = tmp_path / "sample.pdf"
+    pdf.write_bytes(b"data")
+    fake_img = mock.MagicMock()
+
+    monkeypatch.setattr(
+        "backend.app.services.ocr_service.convert_from_path",
+        lambda path, dpi=200: [fake_img],
+    )
+    monkeypatch.setattr(
+        "backend.app.services.ocr_service.pytesseract.image_to_string",
+        lambda img: "text",
+    )
+
+    assert extract_text_from_pdf(str(pdf)) == "text"
+    fake_img.close.assert_called()
+
+
+def test_extract_text_missing_file():
+    with pytest.raises(FileNotFoundError):
+        extract_text_from_pdf("missing.pdf")


### PR DESCRIPTION
## Summary
- add Tesseract-based OCR service and controller
- expose /ocr/extract endpoint
- include OCR tests with mocks
- document OCR usage in README
- add pdf2image and pytesseract to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_688833d9a6a0832da3ee7d50386fe52e