### PR TITLE
Implement /extract endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It now includes basic OCR functionality using Tesseract and pdf2image.
 ## Features
 
 - Create and list document metadata.
-- Extract text from uploaded PDF files via the `/ocr/extract` endpoint.
+- Extract text from uploaded PDF files via the `/ocr/extract` or `/extract` endpoints.
 
 ## Development
 

--- a/backend/app/controllers/ocr_controller.py
+++ b/backend/app/controllers/ocr_controller.py
@@ -8,13 +8,15 @@ import tempfile
 
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
+from ..models.ocr_model import OCRResult
+
 from ..services.ocr_service import extract_text_from_pdf
 
 router = APIRouter()
 
 
-@router.post("/extract")
-async def extract_text(file: UploadFile = File(...)) -> dict[str, str]:
+@router.post("/extract", response_model=OCRResult)
+async def extract_text(file: UploadFile = File(...)) -> OCRResult:
     """Extract text from an uploaded PDF file using OCR."""
     if file.content_type != "application/pdf":
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
@@ -35,4 +37,4 @@ async def extract_text(file: UploadFile = File(...)) -> dict[str, str]:
         if tmp_path and os.path.exists(tmp_path):
             os.remove(tmp_path)
 
-    return {"text": text}
+    return OCRResult(text=text)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,6 +5,7 @@ app = FastAPI(title="Document Management API")
 
 app.include_router(document_routes.router, prefix="/documents", tags=["documents"])
 app.include_router(ocr_routes.router, prefix="/ocr", tags=["ocr"])
+app.include_router(ocr_routes.router, tags=["ocr"])
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/ocr_model.py
+++ b/backend/app/models/ocr_model.py
@@ -1,0 +1,4 @@
+from pydantic import BaseModel
+
+class OCRResult(BaseModel):
+    text: str

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -41,3 +41,22 @@ def test_ocr_endpoint(monkeypatch, tmp_path):
 
     assert resp.status_code == 200
     assert resp.json() == {"text": "ocr text"}
+
+
+def test_extract_endpoint(monkeypatch, tmp_path):
+    sample_pdf = tmp_path / "sample.pdf"
+    sample_pdf.write_bytes(b"dummy")
+
+    monkeypatch.setattr(
+        "backend.app.services.ocr_service.extract_text_from_pdf",
+        lambda path: "ocr text",
+    )
+
+    with sample_pdf.open("rb") as f:
+        resp = client.post(
+            "/extract",
+            files={"file": ("sample.pdf", f, "application/pdf")},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {"text": "ocr text"}


### PR DESCRIPTION
## Summary
- create `OCRResult` response model
- expose OCR controller at `/extract` and `/ocr/extract`
- add unit test for new `/extract` endpoint
- document new endpoint in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6888378e9a28832da63b0e459c3b994c