### PR TITLE
Integrate external AI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It now includes basic OCR functionality using Tesseract and pdf2image.
 
 - Create and list document metadata.
 - Extract text from uploaded PDF files via the `/ocr/extract` or `/extract` endpoints.
+- Generate AI summaries via the `/ai/generate` endpoint.
 
 ## Development
 

--- a/backend/app/controllers/ai_controller.py
+++ b/backend/app/controllers/ai_controller.py
@@ -1,0 +1,15 @@
+from fastapi import APIRouter, HTTPException
+
+from ..models.ai_model import AIRequest, AIResponse
+from ..services.ai_service import generate_summary
+
+router = APIRouter()
+
+
+@router.post("/generate", response_model=AIResponse)
+def generate(request: AIRequest) -> AIResponse:
+    try:
+        result = generate_summary(request.text)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return AIResponse(result=result)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,12 @@
 from fastapi import FastAPI
-from .routes import document_routes, ocr_routes
+from .routes import document_routes, ocr_routes, ai_routes
 
 app = FastAPI(title="Document Management API")
 
 app.include_router(document_routes.router, prefix="/documents", tags=["documents"])
 app.include_router(ocr_routes.router, prefix="/ocr", tags=["ocr"])
 app.include_router(ocr_routes.router, tags=["ocr"])
+app.include_router(ai_routes.router, prefix="/ai", tags=["ai"])
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/ai_model.py
+++ b/backend/app/models/ai_model.py
@@ -1,0 +1,9 @@
+from pydantic import BaseModel
+
+
+class AIRequest(BaseModel):
+    text: str
+
+
+class AIResponse(BaseModel):
+    result: str

--- a/backend/app/routes/ai_routes.py
+++ b/backend/app/routes/ai_routes.py
@@ -1,0 +1,5 @@
+from fastapi import APIRouter
+from ..controllers import ai_controller
+
+router = APIRouter()
+router.include_router(ai_controller.router)

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+"""Integration with external AI API."""
+
+from typing import Any
+import logging
+import os
+
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+logger = logging.getLogger(__name__)
+
+API_URL = os.getenv("AI_API_URL", "https://api.example.com/v1/generate")
+
+
+def _create_session(retries: int = 3, backoff_factor: float = 0.5) -> requests.Session:
+    """Create a requests session with retry strategy."""
+    retry_strategy = Retry(
+        total=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=[429, 500, 502, 503, 504],
+        allowed_methods=["POST"],
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+    session = requests.Session()
+    session.mount("https://", adapter)
+    session.mount("http://", adapter)
+    return session
+
+
+def generate_summary(text: str, timeout: float = 5.0) -> str:
+    """Send text to the external AI API and return the generated summary."""
+    api_key = os.getenv("AI_API_KEY")
+    if not api_key:
+        raise RuntimeError("AI_API_KEY not configured")
+
+    session = _create_session()
+    headers = {"Authorization": f"Bearer {api_key}"}
+    try:
+        response = session.post(API_URL, json={"text": text}, headers=headers, timeout=timeout)
+        response.raise_for_status()
+    except requests.Timeout as exc:
+        logger.error("AI API request timed out: %s", exc)
+        raise RuntimeError("AI API request timed out") from exc
+    except requests.RequestException as exc:
+        logger.error("AI API request failed: %s", exc)
+        raise RuntimeError(f"AI API request failed: {exc}") from exc
+
+    try:
+        data = response.json()
+    except ValueError as exc:
+        logger.error("Invalid AI API response: %s", exc)
+        raise RuntimeError("Invalid AI API response") from exc
+
+    result = data.get("result")
+    if result is None:
+        logger.error("AI API response missing 'result': %s", data)
+        raise RuntimeError("AI API response missing 'result'")
+
+    return str(result)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pdf2image
 pytesseract
+requests

--- a/tests/test_ai_service.py
+++ b/tests/test_ai_service.py
@@ -1,0 +1,33 @@
+import pytest
+from unittest import mock
+
+from backend.app.services.ai_service import generate_summary
+
+
+def test_generate_summary(monkeypatch):
+    monkeypatch.setenv("AI_API_KEY", "key")
+
+    class FakeResponse:
+        def __init__(self):
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"result": "ok"}
+
+    fake_session = mock.MagicMock()
+    fake_session.post.return_value = FakeResponse()
+    monkeypatch.setattr(
+        "backend.app.services.ai_service._create_session", lambda: fake_session
+    )
+
+    assert generate_summary("text") == "ok"
+    fake_session.post.assert_called()
+
+
+def test_generate_summary_missing_key(monkeypatch):
+    monkeypatch.delenv("AI_API_KEY", raising=False)
+    with pytest.raises(RuntimeError):
+        generate_summary("text")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -60,3 +60,19 @@ def test_extract_endpoint(monkeypatch, tmp_path):
 
     assert resp.status_code == 200
     assert resp.json() == {"text": "ocr text"}
+
+
+def test_ai_generate(monkeypatch):
+    monkeypatch.setenv("AI_API_KEY", "k")
+
+    def fake_generate(text):
+        assert text == "hello"
+        return "result"
+
+    monkeypatch.setattr(
+        "backend.app.services.ai_service.generate_summary", fake_generate
+    )
+
+    resp = client.post("/ai/generate", json={"text": "hello"})
+    assert resp.status_code == 200
+    assert resp.json() == {"result": "result"}


### PR DESCRIPTION
## Summary
- add `ai_service` for calling an external AI API using retries and timeouts
- expose `/ai/generate` endpoint
- document the new API route
- add unit tests for the AI service and endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `fastapi` and `backend`)*

------
https://chatgpt.com/codex/tasks/task_b_6888393c9838832d950359a12cd9335d