### PR TITLE
Improve logging and error handling

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,5 @@
+"""Backend application package."""
+
+from .logging_config import setup_logging
+
+setup_logging()

--- a/backend/app/controllers/ai_controller.py
+++ b/backend/app/controllers/ai_controller.py
@@ -1,15 +1,22 @@
+import logging
 from fastapi import APIRouter, HTTPException
 
 from ..models.ai_model import AIRequest, AIResponse
 from ..services.ai_service import generate_summary
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 
 @router.post("/generate", response_model=AIResponse)
 def generate(request: AIRequest) -> AIResponse:
+    logger.info("POST /ai/generate")
     try:
         result = generate_summary(request.text)
     except Exception as exc:
+        logger.error("AI generation failed: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+    logger.info("AI generation successful")
     return AIResponse(result=result)

--- a/backend/app/controllers/document_controller.py
+++ b/backend/app/controllers/document_controller.py
@@ -1,14 +1,24 @@
 from typing import List
-from fastapi import APIRouter
+import logging
+from fastapi import APIRouter, HTTPException
 from ..models.document_model import Document
 from ..services.document_service import document_service
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
 @router.get("/", response_model=List[Document])
 def get_documents():
+    logger.info("GET /documents")
     return document_service.list_documents()
 
 @router.post("/", response_model=Document)
 def create_document(document: Document):
-    return document_service.create_document(document)
+    logger.info("POST /documents")
+    try:
+        return document_service.create_document(document)
+    except ValueError as exc:
+        logger.error("Failed creating document: %s", exc)
+        raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/backend/app/controllers/ocr_controller.py
+++ b/backend/app/controllers/ocr_controller.py
@@ -6,11 +6,15 @@ import os
 import shutil
 import tempfile
 
+import logging
 from fastapi import APIRouter, File, HTTPException, UploadFile
 
 from ..models.ocr_model import OCRResult
 
 from ..services.ocr_service import extract_text_from_pdf
+
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -18,7 +22,9 @@ router = APIRouter()
 @router.post("/extract", response_model=OCRResult)
 async def extract_text(file: UploadFile = File(...)) -> OCRResult:
     """Extract text from an uploaded PDF file using OCR."""
+    logger.info("POST /ocr/extract")
     if file.content_type != "application/pdf":
+        logger.error("Unsupported file type: %s", file.content_type)
         raise HTTPException(status_code=400, detail="Only PDF files are supported")
 
     tmp_path = ""
@@ -29,12 +35,16 @@ async def extract_text(file: UploadFile = File(...)) -> OCRResult:
 
         text = extract_text_from_pdf(tmp_path)
     except FileNotFoundError as exc:
+        logger.error("File not found during OCR: %s", exc)
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except Exception as exc:  # pragma: no cover - external tool failure
+        logger.error("Unexpected OCR error: %s", exc)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
     finally:
         file.file.close()
         if tmp_path and os.path.exists(tmp_path):
             os.remove(tmp_path)
+            logger.debug("Temporary file removed: %s", tmp_path)
 
+    logger.info("OCR extraction successful")
     return OCRResult(text=text)

--- a/backend/app/logging_config.py
+++ b/backend/app/logging_config.py
@@ -1,0 +1,13 @@
+import logging
+import os
+
+
+def setup_logging() -> None:
+    """Configure root logging for the application."""
+    level_name = os.getenv("LOG_LEVEL", "INFO")
+    level = getattr(logging, level_name.upper(), logging.INFO)
+    logging.basicConfig(
+        level=level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,8 @@
+import logging
 from fastapi import FastAPI
 from .routes import document_routes, ocr_routes, ai_routes
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Document Management API")
 
@@ -10,4 +13,5 @@ app.include_router(ai_routes.router, prefix="/ai", tags=["ai"])
 
 @app.get("/")
 def read_root():
+    logger.info("GET /")
     return {"message": "Welcome to the Document Management API"}

--- a/backend/app/services/ai_service.py
+++ b/backend/app/services/ai_service.py
@@ -38,6 +38,7 @@ def generate_summary(text: str, timeout: float = 5.0) -> str:
 
     session = _create_session()
     headers = {"Authorization": f"Bearer {api_key}"}
+    logger.info("Sending text to AI API")
     try:
         response = session.post(API_URL, json={"text": text}, headers=headers, timeout=timeout)
         response.raise_for_status()
@@ -54,9 +55,11 @@ def generate_summary(text: str, timeout: float = 5.0) -> str:
         logger.error("Invalid AI API response: %s", exc)
         raise RuntimeError("Invalid AI API response") from exc
 
+    logger.debug("AI API response: %s", data)
     result = data.get("result")
     if result is None:
         logger.error("AI API response missing 'result': %s", data)
         raise RuntimeError("AI API response missing 'result'")
 
+    logger.info("AI API summary generated")
     return str(result)

--- a/backend/app/services/document_service.py
+++ b/backend/app/services/document_service.py
@@ -1,15 +1,26 @@
 from typing import List
+import logging
+
 from ..models.document_model import Document
+
+
+logger = logging.getLogger(__name__)
 
 class DocumentService:
     def __init__(self):
         self._documents: List[Document] = []
 
     def list_documents(self) -> List[Document]:
+        logger.info("Listing %d documents", len(self._documents))
         return self._documents
 
     def create_document(self, document: Document) -> Document:
+        if any(doc.id == document.id for doc in self._documents):
+            logger.error("Document with id %s already exists", document.id)
+            raise ValueError(f"Document with id {document.id} already exists")
+
         self._documents.append(document)
+        logger.info("Document created: %s", document.id)
         return document
 
 document_service = DocumentService()

--- a/backend/app/services/ocr_service.py
+++ b/backend/app/services/ocr_service.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 """OCR extraction service using Tesseract and pdf2image."""
 
 from typing import List
+import logging
 import os
 
 from pdf2image import convert_from_path
 import pytesseract
+
+
+logger = logging.getLogger(__name__)
 
 
 def extract_text_from_pdf(pdf_path: str) -> str:
@@ -33,21 +37,28 @@ def extract_text_from_pdf(pdf_path: str) -> str:
         If conversion or OCR fails.
     """
     if not os.path.isfile(pdf_path):
+        logger.error("PDF file does not exist: %s", pdf_path)
         raise FileNotFoundError(f"{pdf_path} does not exist")
 
     try:
         # Use a moderate DPI to balance quality and performance
+        logger.info("Converting PDF to images: %s", pdf_path)
         images = convert_from_path(pdf_path, dpi=200)
     except Exception as exc:  # pragma: no cover - external tool failure
+        logger.error("Failed converting PDF to images: %s", exc)
         raise RuntimeError(f"Failed converting PDF to images: {exc}") from exc
 
     texts: List[str] = []
     for img in images:
         try:
+            logger.debug("Running OCR on image")
             texts.append(pytesseract.image_to_string(img))
         except Exception as exc:  # pragma: no cover - external tool failure
+            logger.error("Tesseract OCR failed: %s", exc)
             raise RuntimeError(f"Tesseract OCR failed: {exc}") from exc
         finally:
             img.close()
 
-    return "\n".join(texts)
+    result = "\n".join(texts)
+    logger.info("OCR extraction completed for %s", pdf_path)
+    return result


### PR DESCRIPTION
## Summary
- configure logging for the backend
- add logging setup in package init
- log requests in controllers and services
- handle duplicate documents gracefully

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_b_68883a862070832d910eddc3700a046f