### PR TITLE
Add additional unit tests and docs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,1 +1,18 @@
 # Tests
+
+This project uses **pytest** for all unit and integration tests. Install the
+requirements from `requirements.txt` and run the suite from the repository root:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Test files cover the following components:
+
+- `test_document_service.py` &ndash; unit tests for the in-memory document store.
+- `test_ai_service.py` &ndash; unit tests for the AI API integration.
+- `test_ocr_service.py` &ndash; unit tests for the OCR helpers.
+- `test_app.py` &ndash; integration tests for the FastAPI routes.
+
+Each test is documented with docstrings explaining its purpose.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+# Ensure the repository root is on the Python path for imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_document_service.py
+++ b/tests/test_document_service.py
@@ -1,0 +1,28 @@
+"""Unit tests for the DocumentService."""
+
+import pytest
+
+from backend.app.models.document_model import Document
+from backend.app.services.document_service import DocumentService
+
+
+@pytest.fixture()
+def service():
+    """Return a fresh DocumentService for each test."""
+    return DocumentService()
+
+
+def test_create_and_list_documents(service):
+    """Documents can be created and then listed."""
+    doc = Document(id=1, title="Doc", content="text")
+    created = service.create_document(doc)
+    assert created == doc
+    assert service.list_documents() == [doc]
+
+
+def test_create_document_duplicate(service):
+    """Creating a document with an existing id raises ValueError."""
+    doc = Document(id=1, title="Doc")
+    service.create_document(doc)
+    with pytest.raises(ValueError):
+        service.create_document(doc)


### PR DESCRIPTION
## Summary
- add unit tests for document service
- ensure repo root is on PYTHONPATH for tests
- document how to run the tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68883b764d88832dbcced13c60330cef