### PR TITLE
Add Vite React frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 __pycache__/
 .pytest_cache/
+node_modules/
+frontend/dist/
+*.log

--- a/README.md
+++ b/README.md
@@ -12,3 +12,18 @@ It now includes basic OCR functionality using Tesseract and pdf2image.
 ## Development
 
 Install dependencies from `requirements.txt` and run the tests with `pytest`.
+
+## Frontend
+
+The `frontend` directory contains a standalone React application built with
+[Vite](https://vitejs.dev/). Install its dependencies with `npm install` and
+start the development server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The source code is organized into `components`, `pages`, `services` and `utils`
+for a clean separation from the backend.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,1 +1,19 @@
-# Frontend
+# React Frontend
+
+This directory contains the React application bootstrapped with
+[Vite](https://vitejs.dev/). The project keeps a simple folder structure:
+
+```
+src/
+  components/   reusable UI components
+  pages/        application pages
+  services/     API calls and external integrations
+  utils/        helper utilities
+```
+
+Run the development server from this folder:
+
+```bash
+npm install
+npm run dev
+```

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document Management Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,9 @@
+function App() {
+  return (
+    <div>
+      <h1>Document Management Frontend</h1>
+    </div>
+  )
+}
+
+export default App

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,0 +1,1 @@
+// export components

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,4 @@
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,0 +1,1 @@
+// export pages

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,0 +1,1 @@
+// export services

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,1 @@
+// export utilities

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+})


### PR DESCRIPTION
## Summary
- initialize React project using Vite
- create src structure with components, services, pages and utils
- document how to run the frontend
- update gitignore

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68883d380ff0832dacf274ab121cf4de