### PR TITLE
Implement basic PDF upload UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It now includes basic OCR functionality using Tesseract and pdf2image.
 - Create and list document metadata.
 - Extract text from uploaded PDF files via the `/ocr/extract` or `/extract` endpoints.
 - Generate AI summaries via the `/ai/generate` endpoint.
+- Upload PDF files via the frontend and view the extracted text.
 
 ## Development
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,10 @@
+import { FileUpload } from './components'
+
 function App() {
   return (
     <div>
       <h1>Document Management Frontend</h1>
+      <FileUpload />
     </div>
   )
 }

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { extractText } from '../services'
+
+const MAX_SIZE = 5 * 1024 * 1024 // 5MB
+
+function FileUpload() {
+  const [file, setFile] = useState<File | null>(null)
+  const [error, setError] = useState('')
+  const [result, setResult] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setResult(null)
+    const selected = e.target.files?.[0] || null
+    if (!selected) {
+      setFile(null)
+      return
+    }
+    if (selected.type !== 'application/pdf') {
+      setError('Please select a PDF file.')
+      setFile(null)
+      return
+    }
+    if (selected.size > MAX_SIZE) {
+      setError('File size must be less than 5MB.')
+      setFile(null)
+      return
+    }
+    setError('')
+    setFile(selected)
+  }
+
+  const onUpload = async () => {
+    if (!file) {
+      setError('No file selected.')
+      return
+    }
+    setError('')
+    setLoading(true)
+    try {
+      const text = await extractText(file)
+      setResult(text)
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="upload-container">
+      <input type="file" accept="application/pdf" onChange={onFileChange} />
+      <button onClick={onUpload} disabled={loading}>
+        {loading ? 'Uploading...' : 'Upload'}
+      </button>
+      {error && <p className="error">{error}</p>}
+      {result && (
+        <div className="result">
+          <h3>Extracted Text</h3>
+          <pre>{result}</pre>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default FileUpload

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,1 +1,1 @@
-// export components
+export { default as FileUpload } from './FileUpload'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,3 +2,30 @@ body {
   margin: 0;
   font-family: system-ui, sans-serif;
 }
+
+.upload-container {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-width: 400px;
+  margin: 2rem auto;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.upload-container input[type="file"] {
+  width: 100%;
+}
+
+.upload-container button {
+  padding: 0.5rem;
+}
+
+.upload-container .error {
+  color: red;
+}
+
+.upload-container .result pre {
+  white-space: pre-wrap;
+}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,1 +1,1 @@
-// export services
+export * from './ocrService'

--- a/frontend/src/services/ocrService.ts
+++ b/frontend/src/services/ocrService.ts
@@ -1,0 +1,21 @@
+export async function extractText(file: File): Promise<string> {
+  const formData = new FormData()
+  formData.append('file', file)
+
+  const resp = await fetch('/extract', {
+    method: 'POST',
+    body: formData,
+  })
+
+  if (!resp.ok) {
+    let detail = 'Upload failed'
+    try {
+      const data = await resp.json()
+      detail = data.detail || detail
+    } catch {}
+    throw new Error(detail)
+  }
+
+  const data = await resp.json()
+  return data.text
+}


### PR DESCRIPTION
## Summary
- add PDF upload component and service in React frontend
- style upload form
- expose the new component via index files
- show upload feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: requests, fastapi, pydantic, pdf2image)*

------
https://chatgpt.com/codex/tasks/task_b_6889537da090832d948debfbdc393fbd