### PR TITLE
Integrate Axios in frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ npm run dev
 
 The source code is organized into `components`, `pages`, `services` and `utils`
 for a clean separation from the backend.
+
+All API requests use **Axios**. Configure the backend URL by setting the
+`VITE_API_URL` environment variable before running `npm run dev`.
+

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "axios": "^1.6.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react'
+import axios from 'axios'
 import { extractText } from '../services'
 
 const MAX_SIZE = 5 * 1024 * 1024 // 5MB
@@ -41,7 +42,11 @@ function FileUpload() {
       const text = await extractText(file)
       setResult(text)
     } catch (err: any) {
-      setError(err.message)
+      if (axios.isAxiosError(err)) {
+        setError(err.response?.data?.detail || err.message)
+      } else {
+        setError(err.message)
+      }
     } finally {
       setLoading(false)
     }
@@ -65,3 +70,4 @@ function FileUpload() {
 }
 
 export default FileUpload
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,10 @@
+import axios from 'axios'
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || '',
+  headers: { 'X-Requested-With': 'XMLHttpRequest' },
+  withCredentials: true,
+})
+
+export default api
+

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -1,1 +1,2 @@
+export { default as api } from './api'
 export * from './ocrService'

--- a/frontend/src/services/ocrService.ts
+++ b/frontend/src/services/ocrService.ts
@@ -1,21 +1,15 @@
+import api from './api'
+
 export async function extractText(file: File): Promise<string> {
   const formData = new FormData()
   formData.append('file', file)
 
-  const resp = await fetch('/extract', {
-    method: 'POST',
-    body: formData,
-  })
-
-  if (!resp.ok) {
-    let detail = 'Upload failed'
-    try {
-      const data = await resp.json()
-      detail = data.detail || detail
-    } catch {}
+  try {
+    const resp = await api.post('/extract', formData)
+    return resp.data.text as string
+  } catch (err: any) {
+    const detail = err.response?.data?.detail || err.message || 'Upload failed'
     throw new Error(detail)
   }
-
-  const data = await resp.json()
-  return data.text
 }
+


### PR DESCRIPTION
## Summary
- add axios dependency
- create api helper and refactor OCR service to use axios
- surface axios errors in FileUpload component
- document VITE_API_URL env var in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_688954cd684c832d9554de9c9c850a47