### PR TITLE
Add JSON result display for OCR UI

### DIFF
--- a/frontend/src/components/FileUpload.tsx
+++ b/frontend/src/components/FileUpload.tsx
@@ -1,13 +1,14 @@
 import React, { useState } from 'react'
 import axios from 'axios'
-import { extractText } from '../services'
+import { extractText, OCRResult } from '../services'
+import ResultDisplay from './ResultDisplay'
 
 const MAX_SIZE = 5 * 1024 * 1024 // 5MB
 
 function FileUpload() {
   const [file, setFile] = useState<File | null>(null)
   const [error, setError] = useState('')
-  const [result, setResult] = useState<string | null>(null)
+  const [result, setResult] = useState<OCRResult | null>(null)
   const [loading, setLoading] = useState(false)
 
   const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -39,8 +40,8 @@ function FileUpload() {
     setError('')
     setLoading(true)
     try {
-      const text = await extractText(file)
-      setResult(text)
+      const data = await extractText(file)
+      setResult(data)
     } catch (err: any) {
       if (axios.isAxiosError(err)) {
         setError(err.response?.data?.detail || err.message)
@@ -59,12 +60,7 @@ function FileUpload() {
         {loading ? 'Uploading...' : 'Upload'}
       </button>
       {error && <p className="error">{error}</p>}
-      {result && (
-        <div className="result">
-          <h3>Extracted Text</h3>
-          <pre>{result}</pre>
-        </div>
-      )}
+      {result && <ResultDisplay data={result} />}
     </div>
   )
 }

--- a/frontend/src/components/ResultDisplay.tsx
+++ b/frontend/src/components/ResultDisplay.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+interface ResultDisplayProps {
+  data: any
+}
+
+function ResultDisplay({ data }: ResultDisplayProps) {
+  if (!data) return null
+
+  const formatted = JSON.stringify(data, null, 2)
+
+  return (
+    <div className="json-output">
+      <h3>OCR Result</h3>
+      <pre>{formatted}</pre>
+    </div>
+  )
+}
+
+export default ResultDisplay

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -1,1 +1,2 @@
 export { default as FileUpload } from './FileUpload'
+export { default as ResultDisplay } from './ResultDisplay'

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -29,3 +29,11 @@ body {
 .upload-container .result pre {
   white-space: pre-wrap;
 }
+
+.json-output {
+  background-color: #f5f5f5;
+  padding: 1rem;
+  border-radius: 4px;
+  font-family: monospace;
+  overflow-x: auto;
+}

--- a/frontend/src/services/ocrService.ts
+++ b/frontend/src/services/ocrService.ts
@@ -1,12 +1,16 @@
 import api from './api'
 
-export async function extractText(file: File): Promise<string> {
+export interface OCRResult {
+  text: string
+}
+
+export async function extractText(file: File): Promise<OCRResult> {
   const formData = new FormData()
   formData.append('file', file)
 
   try {
     const resp = await api.post('/extract', formData)
-    return resp.data.text as string
+    return resp.data as OCRResult
   } catch (err: any) {
     const detail = err.response?.data?.detail || err.message || 'Upload failed'
     throw new Error(detail)


### PR DESCRIPTION
## Summary
- return full OCR result object from the extract service
- show OCR results using new `ResultDisplay` component
- format JSON output with new styling

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6889569fe944832db6b5d42fcd42e72d