### PR TITLE
Improve project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,68 @@
 # Document Management API
 
-This repository contains a minimal FastAPI application for managing documents.
-It now includes basic OCR functionality using Tesseract and pdf2image.
+This project provides a small document management service built with
+[FastAPI](https://fastapi.tiangolo.com/). It exposes a REST API for storing
+document metadata, extracting text from uploaded PDFs and generating summaries
+via an external AI service. A simple React frontend is included for uploading
+files and viewing results.
 
 ## Features
 
-- Create and list document metadata.
-- Extract text from uploaded PDF files via the `/ocr/extract` or `/extract` endpoints.
-- Generate AI summaries via the `/ai/generate` endpoint.
-- Upload PDF files via the frontend and view the extracted text.
+- CRUD style endpoints for storing document metadata in memory
+- OCR extraction using **Tesseract** through `pdf2image` and `pytesseract`
+- AI summarisation by calling an external API
+- Dockerfile for containerised deployments
+- React frontend powered by **Vite**
 
-## Development
+## Requirements
 
-Install dependencies from `requirements.txt` and run the tests with `pytest`.
+- Python 3.11+
+- Node.js (for the frontend)
+- Tesseract OCR installed on the host machine
+
+The backend dependencies are listed in `requirements.txt`. The tests require the
+same packages.
+
+## Setup
+
+Clone the repository and install the Python requirements. If `virtualenv` or a
+similar tool is available, create an isolated environment first.
+
+```bash
+git clone <repo-url>
+cd document-management
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+The application reads two environment variables when calling the AI service:
+
+- `AI_API_KEY` &ndash; API key for the external provider
+- `AI_API_URL` &ndash; optional override for the API endpoint
+
+## Running the Backend
+
+Start the API locally with Uvicorn:
+
+```bash
+uvicorn backend.app.main:app --reload
+```
+
+The server listens on <http://localhost:8000> by default.
+
+### Tests
+
+Run the unit and integration tests with `pytest` from the repository root:
+
+```bash
+pytest
+```
 
 ## Frontend
 
-The `frontend` directory contains a standalone React application built with
-[Vite](https://vitejs.dev/). Install its dependencies with `npm install` and
-start the development server:
+The `frontend` directory holds a standalone React application. To launch the
+development server:
 
 ```bash
 cd frontend
@@ -26,9 +70,17 @@ npm install
 npm run dev
 ```
 
-The source code is organized into `components`, `pages`, `services` and `utils`
-for a clean separation from the backend.
+Set the `VITE_API_URL` environment variable if the backend runs on another URL.
 
-All API requests use **Axios**. Configure the backend URL by setting the
-`VITE_API_URL` environment variable before running `npm run dev`.
+## Docker Deployment
+
+To build and run the API as a container:
+
+```bash
+docker build -t document-api .
+docker run -p 8000:8000 document-api
+```
+
+The Docker image installs the Python dependencies and runs the FastAPI
+application on port `8000`.
 


### PR DESCRIPTION
## Summary
- expand the README with clear setup and deployment instructions

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_b_6889583ab224832d984ddfc97af35573