### PR TITLE
Add .env.example with variable descriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Example environment configuration for the Document Management project
+
+# ---------------------------------------------------------------------------
+# Backend settings
+# ---------------------------------------------------------------------------
+
+# AI_API_KEY is required to authenticate with the external AI provider used
+# when generating document summaries.
+# Replace 'your-api-key' with the value supplied by your provider.
+AI_API_KEY=your-api-key
+
+# AI_API_URL defines the endpoint of the external AI service.
+# Optional. Defaults to "https://api.example.com/v1/generate" when unset.
+AI_API_URL=https://api.example.com/v1/generate
+
+# LOG_LEVEL controls the verbosity of the backend logs.
+# Common values are DEBUG, INFO, WARNING and ERROR. Optional.
+LOG_LEVEL=INFO
+
+# ---------------------------------------------------------------------------
+# Frontend settings
+# ---------------------------------------------------------------------------
+
+# VITE_API_URL specifies the base URL of the backend API the React frontend
+# will call. Set this when running the frontend separately from the backend.
+# Example: http://localhost:8000
+VITE_API_URL=http://localhost:8000
+

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ The application reads two environment variables when calling the AI service:
 - `AI_API_KEY` &ndash; API key for the external provider
 - `AI_API_URL` &ndash; optional override for the API endpoint
 
+All available environment variables are described in the accompanying
+`.env.example` file.
+
 ## Running the Backend
 
 Start the API locally with Uvicorn:


### PR DESCRIPTION
## Summary
- add `.env.example` to list environment variables with explanations
- link to `.env.example` from README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_b_68898c8d8cfc832dbe79d2ae87585a87